### PR TITLE
Fix/rename logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ It supports four levels, default being `INFO`.
 
 ## Usage
 
-Source the `tinylogger.bash` file, and use the `logger` method.
+Source the `tinylogger.bash` file, and use the `tlog` method.
 The first argument is the level, and the second the log message.
 
     source tinylogger.bash
-    logger warn "This is a warning"
+    tlog warn "This is a warning"
 
 See [`demo.sh`](./demo.sh) for more.
 
@@ -41,6 +41,8 @@ You can control the logging level while calling a script by setting the `LOGGER_
 2017-11-07 19:05:52 - DEBUG - end of script
 2017-11-07 19:05:52 - INFO - Script completed, go home
 ```
+
+You can set `LOGGER_LVL=none` to disable all logging.
 
 ## Timestamp customisation
 

--- a/demo.sh
+++ b/demo.sh
@@ -3,14 +3,14 @@
 
 source tinylogger.bash
 
-logger debug "first line of script"
-logger info "Starting script $0"
-logger debug "another debug statement"
+tlog debug "first line of script"
+tlog info "Starting script $0"
+tlog debug "another debug statement"
 
-logger info "Current time is $( date )"
-logger warn "This is a scary warning"
-logger debug "do you like these debug statements?"
-logger error "Something terrible has happened"
+tlog info "Current time is $( date )"
+tlog warn "This is a scary warning"
+tlog debug "do you like these debug statements?"
+tlog error "Something terrible has happened"
 
-logger debug "end of script"
-logger info "Script completed, go home"
+tlog debug "end of script"
+tlog info "Script completed, go home"

--- a/tinylogger.bash
+++ b/tinylogger.bash
@@ -1,4 +1,4 @@
-# logging.bash - A simple logging framework for Bash scripts in 10 lines
+# tinylogger.bash - A simple logging framework for Bash scripts in < 10 lines
 # https://github.com/nk412/tinylogger
 
 # Copyright (c) 2017 Nagarjuna Kumarappan
@@ -25,11 +25,12 @@
 
 if [ "$LOGGER_FMT" == "" ]; then LOGGER_FMT="%Y-%m-%d %H:%M:%S"; fi
 if [ "$LOGGER_LVL" == "" ]; then LOGGER_LVL="info" ; fi
-function logger {
+function tlog {
     action=$1 && shift
-    case $action in debug)  [[ $LOGGER_LVL =~ debug ]]           && echo "$( date "+${LOGGER_FMT}" ) - DEBUG - $@" 1>&2 ;;
-                    info)   [[ $LOGGER_LVL =~ debug|info ]]      && echo "$( date "+${LOGGER_FMT}" ) - INFO - $@" 1>&2  ;;
-                    warn)   [[ $LOGGER_LVL =~ debug|info|warn ]] && echo "$( date "+${LOGGER_FMT}" ) - WARN - $@" 1>&2  ;;
-                    error)  [[ ! $LOGGER_LVL =~ none ]]          && echo "$( date "+${LOGGER_FMT}" ) - ERROR - $@" 1>&2 ;;
+    case $action in 
+        debug)  [[ $LOGGER_LVL =~ debug ]]           && echo "$( date "+${LOGGER_FMT}" ) - DEBUG - $@" 1>&2 ;;
+        info)   [[ $LOGGER_LVL =~ debug|info ]]      && echo "$( date "+${LOGGER_FMT}" ) - INFO - $@" 1>&2  ;;
+        warn)   [[ $LOGGER_LVL =~ debug|info|warn ]] && echo "$( date "+${LOGGER_FMT}" ) - WARN - $@" 1>&2  ;;
+        error)  [[ ! $LOGGER_LVL =~ none ]]          && echo "$( date "+${LOGGER_FMT}" ) - ERROR - $@" 1>&2 ;;
     esac
     true; }


### PR DESCRIPTION
`logger` is already a valid binary in most linux systems. Changes the method name to `tlog`.
Thanks _/u/florianbeer_